### PR TITLE
Auto Open in Browser

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "license": "MIT",
   "scripts": {
     "build": "gatsby build",
-    "develop": "gatsby develop",
+    "dev": "gatsby develop -p 3000 -o",
     "format": "prettier --write \"**/*.{js,jsx,json,md}\"",
     "start": "npm run develop",
     "serve": "gatsby serve",


### PR DESCRIPTION
appended `-p 3000 -o` to the `develop` npm script & changed `develop` to `dev`. Now when you run `npm run dev` it will build the project in development mode and auto open in browser navigating to the build URL.